### PR TITLE
Update old-point in go-eldoc--goto-beginning-of-funcall between iterations

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -89,6 +89,7 @@
                    (not (= old-point (point)))
                    (not (go-eldoc--begining-of-funcall-p)))
         do
+        (setq old-point (point))
         (go-goto-opening-parenthesis)
         finally return (go-eldoc--begining-of-funcall-p)))
 


### PR DESCRIPTION
The current behaviour only works because of an unintended side-effect
in go-goto-opening-parenthesis, where it will jump to the beginning of
the buffer if point isn't in a balanced pair of parentheses. Future
versions of go-goto-opening-parenthesis will not move point at all.

With the change to go-goto-opening-parenthesis, the old implementation
of go-eldoc--goto-beginning-of-funcall could end up in an infinite
loop.
