### PR TITLE
use a simple looking-back instead of movement and string matching in go-eldoc--beginning-of-funcall-p

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -75,12 +75,8 @@
         (match-string-no-properties 1 candidates)))))
 
 (defun go-eldoc--begining-of-funcall-p ()
-  (let ((curpoint (point)))
-    (save-excursion
-      (skip-chars-backward "a-zA-Z0-9_ ")
-      (string-match "[a-zA-Z0-9_]+\\s-*("
-                    (buffer-substring-no-properties
-                     (point) (1+ curpoint))))))
+  (and (= (char-after) ?\()
+       (looking-back "[a-zA-Z0-9_]+\\s-*")))
 
 (defun go-eldoc--goto-beginning-of-funcall ()
   (loop with old-point = (point)


### PR DESCRIPTION
Partly this is a mere simplification to clarify the function. It also fixes an issue where (1+ curpoint) will not be a valid point, when curpoint was at the end of the buffer already.
