### PR TITLE
Fix byte-compile warning

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -279,7 +279,7 @@
   (interactive)
   (set (make-local-variable 'eldoc-documentation-function)
        'go-eldoc--documentation-function)
-  (turn-on-eldoc-mode))
+  (eldoc-mode +1))
 
 (provide 'go-eldoc)
 


### PR DESCRIPTION
turn-on-eldoc-mode is obsoleted from Emacs 24.4.
