### PR TITLE
Update go-mode version for using dominikh's go-mode

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -5,7 +5,7 @@
 ;; Author: Syohei YOSHIDA <syohex@gmail.com>
 ;; URL: https://github.com/syohex/emacs-go-eldoc
 ;; Version: 0.21
-;; Package-Requires: ((go-mode "0") (cl-lib "0.5"))
+;; Package-Requires: ((go-mode "1.0.0") (cl-lib "0.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
go-mode was provided by Go itself. But it was removed and we should use
dominikh's go-mode.