### PR TITLE
Case sensitive match

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -115,7 +115,8 @@
     (let* ((cands (if (string= candidates "")
                       (go-eldoc--search-builtin-functions cur-symbol curpoint)
                     candidates))
-           (regexp (format "^\\(%s,,\\(?:func\\|type\\).+\\)$" cur-symbol)))
+           (regexp (format "^\\(%s,,\\(?:func\\|type\\).+\\)$" cur-symbol))
+           (case-fold-search nil))
       (when (and cands (string-match regexp cands))
         (match-string-no-properties 1 cands)))))
 
@@ -337,14 +338,15 @@
                  (plist-get signature :real-type)))))))
 
 (defun go-eldoc--retrieve-type (typeinfo symbol)
-  (cond ((string-match (format "^%s,,var \\(.+\\)$" symbol) typeinfo)
-         (match-string 1 typeinfo))
-        ((string-match-p (format "\\`%s,,package\\s-*$" symbol) typeinfo)
-         "package")
-        ((string-match (format "^%s,,\\(func.+\\)$" symbol) typeinfo)
-         (match-string 1 typeinfo))
-        ((string-match (format "^%s,,\\(.+\\)$" symbol) typeinfo)
-         (match-string 1 typeinfo))))
+  (let ((case-fold-search nil))
+    (cond ((string-match (format "^%s,,var \\(.+\\)$" symbol) typeinfo)
+           (match-string 1 typeinfo))
+          ((string-match-p (format "\\`%s,,package\\s-*$" symbol) typeinfo)
+           "package")
+          ((string-match (format "^%s,,\\(func.+\\)$" symbol) typeinfo)
+           (match-string 1 typeinfo))
+          ((string-match (format "^%s,,\\(.+\\)$" symbol) typeinfo)
+           (match-string 1 typeinfo)))))
 
 (defun go-eldoc--get-cursor-info (bounds)
   (save-excursion

--- a/test/function.el
+++ b/test/function.el
@@ -499,4 +499,25 @@ func main() {
           (expected "foo: (bar func(a int, b int) (chan<- string), baz int) int"))
       (should (string= got expected)))))
 
+(ert-deftest case-sensitive-match-function ()
+  "Match only case sensitive"
+  (with-go-temp-buffer
+    "
+package main
+
+import \"os\"
+
+func main() {
+        os.MkDIR( )
+        os.Mkdir( )
+}
+"
+    (forward-cursor-on "( )")
+    (forward-char 1)
+    (should-not (go-eldoc--documentation-function))
+
+    (forward-cursor-on "( )")
+    (forward-char 1)
+    (should (go-eldoc--documentation-function))))
+
 ;;; function.el end here

--- a/test/not-function.el
+++ b/test/not-function.el
@@ -193,4 +193,23 @@ func foo() {
           (expected "fmt: package"))
       (should (string= got expected)))))
 
+(ert-deftest case-sensitive-match-type ()
+  "Match only case sensitive"
+  (with-go-temp-buffer
+    "
+package main
+
+import \"os\"
+
+func main() {
+        os.MkDIR( )
+        os.Mkdir( )
+}
+"
+    (forward-cursor-on "MkDIR")
+    (should-not (go-eldoc--documentation-function))
+
+    (forward-cursor-on "Mkdir")
+    (should (go-eldoc--documentation-function))))
+
 ;;; not-function.el end here


### PR DESCRIPTION
Because golang is case-sensitive language.
