### PR TITLE
Kill existing go-eldoc buffer to prevent duplicates

### DIFF
--- a/go-eldoc.el
+++ b/go-eldoc.el
@@ -152,6 +152,9 @@
            finally return retval))
 
 (defun go-eldoc--invoke-autocomplete ()
+  (when (get-buffer "*go-eldoc*")
+    (kill-buffer "*go-eldoc*"))
+
   (let ((temp-buffer (get-buffer-create "*go-eldoc*"))
         (gocode-args (append go-eldoc-gocode-args
                              (list "-f=emacs"


### PR DESCRIPTION
Previously when using any of the gocode variants and rapidlytriggering go-eldoc to show eldoc info in the modebar, if the context was killed by gocode this would result in multiple go-eldoc buffers. This commit now ensures that if an initial go-eldoc buffer exists, it is killed before the new temp-buffer is created. This is really naive, though I've confirmed this solution results in no duplicate buffers being created.

### Replication Steps
0. Install melpa package and suggested go dependencies
1. Open any `.go` file with _something_ defined (variables, functions, structs, etc)
2. Based on the timeout value before go-eldoc shows the definition of what is under the cursor, move the cursor between letters in a definition
3. If your timing is nearly perfect, an additional `*go-eldoc*` buffer is created

Please let me know if I have not explained this well enough, I'm finding it a bit difficult to succinctly express this bug.